### PR TITLE
quickfix: remove hero video

### DIFF
--- a/_src/_assets/javascripts/page-front.js
+++ b/_src/_assets/javascripts/page-front.js
@@ -1,13 +1,10 @@
 
-//=include bigchain/hero-video.js
 //=include bigchain/smoothscroll.js
 //=include bigchain/testimonials.js
 
 jQuery(function($) {
 
     // hero stuff
-    HeroVideo.init();
-
     $('.hero .logo').on('animationend webkitAnimationEnd oAnimationEnd',
         function(e) {
             $('.hero').addClass('is-ready');

--- a/_src/_includes/hero-video.html
+++ b/_src/_includes/hero-video.html
@@ -20,10 +20,6 @@
     </div>
 
     <div class="hero-video__background">
-        <video class="hero-video__video" poster="/assets/img/northern-lights-poster.jpg" preload="none" loop>
-            <source src="/assets/videos/{{ page.hero_video_name }}.mp4" type="video/mp4">
-            <source src="/assets/videos/{{ page.hero_video_name }}.webm" type="video/webm">
-        </video>
         <img class="hero-video__poster" width="1920" height="1080" src="/assets/img/northern-lights-poster.jpg" />
     </div>
 


### PR DESCRIPTION
That whole video loading thingy is hard to debug across all the browsers so let's do a quickfix for now. This PR just removes the hero video markup and js loading.

Addressing #91 