### PR TITLE
Fix partner titles

### DIFF
--- a/_src/_layouts/partner.html
+++ b/_src/_layouts/partner.html
@@ -13,7 +13,7 @@ cta:
 
     <div class="row">
         <hgroup>
-            <h1 class="header__title">{{ page.name }}</h1>
+            <h1 class="header__title">{{ page.title }}</h1>
         </hgroup>
     </div>
 </header>
@@ -24,7 +24,7 @@ cta:
 
     <div class="row row--narrow">
         <svg class="partner__logo partner__logo--{{ slug }}" aria-labelledby="title">
-            <title>{{ page.name }}</title>
+            <title>{{ page.title }}</title>
             <use xlink:href="/assets/img/sprite.svg#logo-{{ slug }}"></use>
         </svg>
 
@@ -34,7 +34,7 @@ cta:
             {% if page.usecase %}
                 <a class="btn btn-sm btn-primary" href="/usecases/{{ page.usecase }}">See use case</a>
             {% endif %}
-            <a href="{{ page.link }}" rel="external">Visit {{ page.name }}</a>
+            <a href="{{ page.link }}" rel="external">Visit {{ page.title }}</a>
         </aside>
     </div>
 

--- a/_src/_partners/capgemini.md
+++ b/_src/_partners/capgemini.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Capgemini
+title: Capgemini
 link: https://www.capgemini.com
 ---
 

--- a/_src/_partners/cognizant.md
+++ b/_src/_partners/cognizant.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Cognizant
+title: Cognizant
 link: https://www.cognizant.com
 ---
 

--- a/_src/_partners/innogy.md
+++ b/_src/_partners/innogy.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: innogy SE
+title: innogy SE
 link: https://www.innogy.com/
 usecase: /supplychain/innogy/
 header: hero-innogy.jpg

--- a/_src/_partners/interledger.md
+++ b/_src/_partners/interledger.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Interledger
+title: Interledger
 link: https://interledger.org
 ---
 

--- a/_src/_partners/ipdb.md
+++ b/_src/_partners/ipdb.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: IPDB
+title: IPDB
 link: https://ipdb.foundation
 header: hero-ipdb.jpg
 ---

--- a/_src/_partners/microsoft.md
+++ b/_src/_partners/microsoft.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Microsoft
+title: Microsoft
 link: https://www.microsoft.com
 ---
 

--- a/_src/_partners/monax.md
+++ b/_src/_partners/monax.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Monax
+title: Monax
 link: https://monax.io
 ---
 

--- a/_src/_partners/mongodb.md
+++ b/_src/_partners/mongodb.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: MongoDB
+title: MongoDB
 link: https://www.mongodb.com
 ---
 

--- a/_src/_partners/recruit-technologies.md
+++ b/_src/_partners/recruit-technologies.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Recruit Technologies
+title: Recruit Technologies
 link: http://recruit-tech.co.jp
 usecase: /identity/recruit/
 header: hero-recruit.jpg

--- a/_src/_partners/rethinkdb.md
+++ b/_src/_partners/rethinkdb.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: ReThinkDB
+title: ReThinkDB
 link: https://www.rethinkdb.com
 ---
 

--- a/_src/_partners/tangent90.md
+++ b/_src/_partners/tangent90.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Tangent90
+title: Tangent90
 link: http://www.tangent90.co.uk
 ---
 

--- a/_src/_partners/tymlez.md
+++ b/_src/_partners/tymlez.md
@@ -1,7 +1,7 @@
 ---
 layout: partner
 
-name: Tymlez
+title: Tymlez
 link: http://www.tymlez.com
 ---
 


### PR DESCRIPTION
Fixes the meta title attribute and header title so it respects the exact writing. Cause we don't want this ending up in Google although company name is specifically set to `MongoDB`:

<img width="622" alt="screen shot 2017-04-10 at 20 23 24" src="https://cloud.githubusercontent.com/assets/90316/24876328/9bbe9a06-1e2b-11e7-910d-9240e60944a7.png">
