### PR TITLE
Make headers use optional tagline

### DIFF
--- a/_src/_assets/styles/_page-features.scss
+++ b/_src/_assets/styles/_page-features.scss
@@ -36,7 +36,6 @@
 }
 
 .feature__text {
-    @extend .text-dimmed;
     margin-bottom: 0;
 }
 

--- a/_src/_assets/styles/_page-usecases.scss
+++ b/_src/_assets/styles/_page-usecases.scss
@@ -10,9 +10,13 @@
     }
 
     .section-description {
-        margin-bottom: $spacer * 2;
-        padding-bottom: $spacer * 2;
+        margin-bottom: $spacer * 3;
+        padding-bottom: $spacer * 3;
         border-bottom: 2px solid lighten($gray-dark, 10%);
+    }
+
+    .grid {
+        margin-bottom: 0;
     }
 }
 

--- a/_src/_assets/styles/bigchain/_content-page.scss
+++ b/_src/_assets/styles/bigchain/_content-page.scss
@@ -8,8 +8,8 @@
     padding-bottom: ($spacer * 2);
 
     @media ($screen-sm) {
-        padding-top: ($spacer * 4);
-        padding-bottom: ($spacer * 4);
+        padding-top: ($spacer * 5);
+        padding-bottom: ($spacer * 5);
     }
 
     > h1, h2 {

--- a/_src/_assets/styles/bigchain/_header.scss
+++ b/_src/_assets/styles/bigchain/_header.scss
@@ -7,5 +7,5 @@
     z-index: 1;
     text-align: center;
     margin: 0;
-    padding: ($spacer * 6) 0;
+    padding: ($spacer * 5) 0;
 }

--- a/_src/_assets/styles/bigchain/_sections.scss
+++ b/_src/_assets/styles/bigchain/_sections.scss
@@ -14,8 +14,8 @@
     }
 
     @media ($screen-sm) {
-        padding-top: ($spacer * 6);
-        padding-bottom: ($spacer * 6);
+        padding-top: ($spacer * 5);
+        padding-bottom: ($spacer * 5);
     }
 }
 
@@ -53,6 +53,7 @@
 .section-description {
     font-size: $font-size-lg;
     margin-bottom: 0;
+    color: $brand-main-gray-lighter;
 
     + .section-description {
         margin-top: $spacer;

--- a/_src/_assets/styles/bigchain/_variables.scss
+++ b/_src/_assets/styles/bigchain/_variables.scss
@@ -68,7 +68,7 @@ $headings-color:            $brand-main-blue-light !default;
 // Scaffolding
 //
 $body-bg:                   $brand-main-gray !default;
-$text-color:                $brand-main-gray-lighter !default;
+$text-color:                $brand-main-gray-light !default;
 
 $link-color:                inherit !default;
 $link-hover-color:          #fff !default;

--- a/_src/_layouts/page.html
+++ b/_src/_layouts/page.html
@@ -7,7 +7,13 @@ layout: base
     {% include menu-main.html %}
 
     <div class="row">
-        <h1 class="header__title">{{ page.title }}</h1>
+        <h1 class="header__title">
+            {% if page.tagline %}
+                {{ page.tagline }}
+            {% else %}
+                {{ page.title }}
+            {% endif %}
+        </h1>
     </div>
 </header>
 

--- a/_src/community.html
+++ b/_src/community.html
@@ -2,6 +2,7 @@
 layout: page
 
 title: Community
+tagline: "Get Involved"
 description: 'There are many ways you can contribute to the BigchainDB project, some very easy and others more involved.'
 
 image: photo2.jpg
@@ -13,7 +14,6 @@ quotes: set3
 <section class="section section-community">
     <div class="row">
         <header class="section-header">
-            <h1 class="section-title">Get Involved</h1>
             <p class="section-description">There are many ways you can contribute to the BigchainDB project, some very easy and others more involved. We welcome all potential contributors, so we ask that everyone participating abide by some simple guidelines.</p>
 
             <a href="https://github.com/{{ site.github.org }}/bigchaindb/blob/master/CONTRIBUTING.md" class="btn btn-primary btn-sm">Read The Guidelines</a>

--- a/_src/contact.html
+++ b/_src/contact.html
@@ -2,14 +2,11 @@
 layout: page
 
 title: Contact
+tagline: Get In Touch
 ---
 
 <section class="section section-contactform">
     <div class="row row--wide">
-        <header class="section-header">
-            <h1 class="section-title">Get In Touch</h1>
-        </header>
-
         <div class="grid grid--full grid-medium--columns grid--gutters">
             <div class="grid__col grid__col--4">
                 {% include/form-contact.html %}

--- a/_src/usecases.html
+++ b/_src/usecases.html
@@ -2,12 +2,12 @@
 layout: page
 
 title: Use Cases
+tagline: Where blockchains and databases meet
 description: For blockchain technology to go mainstream, it needs scale. At BigchainDB, we’ve taken care of that for you.
 
 image: photo4.jpg
 
 intro:
-    title: Where blockchains and databases meet
     description: "BigchainDB is for developers and organizations looking for a scalable, queryable database with blockchain characteristics such as decentralization, immutability and the ability to treat anything stored in the database as an asset. Whether it’s atoms, bits or bytes of value, any real-world blockchain application needs scale and performance. A perfect fit for BigchainDB."
     addition: "We’re still in the early days of the decentralization movement and while all of the industries below are being disrupted in one way or another, there’s an abundance of opportunity within each."
     contact:
@@ -24,17 +24,16 @@ js: page-usecases.min.js
 <section class="section section--intro">
     <div class="row">
         <header class="section-header">
-            <h1 class="section-title">{{ page.intro.title }}</h1>
-                <p class="section-description">{{ page.intro.description }}</p>
+            <p class="section-description">{{ page.intro.description }}</p>
 
-                <div class="grid grid--full grid-small--half grid--gutters grid--top text-left">
-                    <div class="grid__col">
-                        {{ page.intro.addition }}
-                    </div>
-                    <div class="grid__col">
-                        <p><strong>{{ page.intro.contact.text }}</strong> <br><a href="{{ page.intro.contact.link }}">{{ page.intro.contact.action }}</a></p>
-                    </div>
+            <div class="grid grid--full grid-small--half grid--gutters grid--top text-left">
+                <div class="grid__col">
+                    {{ page.intro.addition }}
                 </div>
+                <div class="grid__col">
+                    <p><strong>{{ page.intro.contact.text }}</strong> <br><a href="{{ page.intro.contact.link }}">{{ page.intro.contact.action }}</a></p>
+                </div>
+            </div>
         </header>
     </div>
 </section>

--- a/_src/whitepaper/index.md
+++ b/_src/whitepaper/index.md
@@ -2,6 +2,7 @@
 layout: page
 
 title: Whitepaper
+tagline: "BigchainDB: A Scalable Blockchain Database"
 description: 'This paper describes BigchainDB. BigchainDB fills a gap in the decentralization ecosystem: a decentralized database, at scale. It is capable of 1 million writes per second throughput, storing petabytes of data, and sub-second latency.'
 
 image: photo3.jpg
@@ -14,8 +15,6 @@ whitepaper:
         - file: bigchaindb-whitepaper.pdf
           button: Download PDF
 ---
-
-## BigchainDB: A Scalable Blockchain Database
 
 *by <br>Trent McConaghy, Rodolphe Marques, Andreas Müller, Dimitri De Jonghe, Troy McConaghy, Greg McMullen, Ryan Henderson, Sylvain Bellemare, Alberto Granzotto*
 


### PR DESCRIPTION
Starting every page with the page title and another heading is kinda redundant, gets the message across not effectively, and wastes lots of space. This PR introduces an optional `tagline` key, when present in a page's YAML front matter, it will be displayed in the header. When you see it, it makes so much more sense.

Along with some more space saving tweaks.

### tl;dr

before:

<img width="1042" alt="screen shot 2017-04-11 at 14 02 56" src="https://cloud.githubusercontent.com/assets/90316/24908248/9deaafb0-1ebf-11e7-84fd-ea2f023e58ef.png">

after:

<img width="1043" alt="screen shot 2017-04-11 at 14 03 03" src="https://cloud.githubusercontent.com/assets/90316/24908257/a57c0454-1ebf-11e7-97c6-18608efc1f58.png">
