### PR TITLE
Autoprefixer 7

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -50,9 +50,6 @@ console.log("")
 // Port to use for the development server
 const PORT = 1337
 
-// Browsers to target when prefixing CSS
-const COMPATIBILITY = ['last 2 versions', 'Chrome >= 30', 'Safari >= 6.1', 'Firefox >= 35', 'Opera >= 32', 'iOS >= 8', 'Android >= 4', 'ie >= 10']
-
 // paths
 const SRC      = site.source + '/',
       DIST     = site.destination + '/'
@@ -154,7 +151,7 @@ export const css = () => src(SRC + '_assets/styles/bigchain.scss')
     .pipe($.sass({
         includePaths: ['node_modules']
     }).on('error', $.sass.logError))
-    .pipe($.autoprefixer({ browsers: COMPATIBILITY }))
+    .pipe($.autoprefixer())
     .pipe($.if(isProduction || isStaging, $.cleanCss()))
     .pipe($.if(!(isProduction || isStaging), $.sourcemaps.write()))
     .pipe($.if(isProduction || isStaging, $.header(BANNER, { pkg: pkg })))

--- a/package.json
+++ b/package.json
@@ -13,6 +13,16 @@
     "start": "gulp",
     "build": "gulp build --production"
   },
+  "browserslist": [
+    "last 2 versions",
+    "Chrome >= 30",
+    "Safari >= 6.1",
+    "Firefox >= 35",
+    "Opera >= 32",
+    "iOS >= 8",
+    "Android >= 4",
+    "ie >= 10"
+  ],
   "dependencies": {
     "is-in-viewport": "^3.0.0",
     "jquery": "^3.1.1",


### PR DESCRIPTION
So much good stuff: https://evilmartians.com/chronicles/autoprefixer-7-browserslist-2-released

PR bumps `gulp-autoprefixer` version which makes it use `autoprefixer` 7.