### PR TITLE
Track enterprise submissions in Google Analytics

### DIFF
--- a/_src/_assets/javascripts/bigchain/analytics.js
+++ b/_src/_assets/javascripts/bigchain/analytics.js
@@ -157,6 +157,14 @@ var GoogleAnalytics = (function(w,d,$) {
         },
         gaEventClaError: function() {
             ga('send', 'event', 'cla', 'cla_form', 'error');
+        },
+
+        // Enterprise form
+        gaEventEnterpriseSuccess: function() {
+            ga('send', 'event', 'enterprise', 'enterprise_form', 'success');
+        },
+        gaEventEnterpriseError: function() {
+            ga('send', 'event', 'enterprise', 'enterprise_form', 'error');
         }
     };
 

--- a/_src/_assets/javascripts/bigchain/form-enterprise.js
+++ b/_src/_assets/javascripts/bigchain/form-enterprise.js
@@ -35,7 +35,7 @@ var FormEnterprise = (function(w, d, $) {
 
                             // send GA event
                             if (!_dntEnabled()) {
-                                //GoogleAnalytics.gaEventContactSuccess();
+                                GoogleAnalytics.gaEventEnterpriseSuccess();
                             }
                         },
                         error: function(err) {
@@ -46,7 +46,7 @@ var FormEnterprise = (function(w, d, $) {
 
                             // send GA event
                             if (!_dntEnabled()) {
-                                //GoogleAnalytics.gaEventContactError();
+                                GoogleAnalytics.gaEventEnterpriseError();
                             }
                         }
                     });


### PR DESCRIPTION
Sets up 2 custom Google Analytics events (success & error) for the enterprise form, which are being send to Google Analytics upon form submission.

Will be used to track a new goal in GA so we get the conversion rate for the enterprise page.