### PR TITLE
Make form labels within input groups less high

### DIFF
--- a/_src/_assets/styles/bigchain/_input-group.scss
+++ b/_src/_assets/styles/bigchain/_input-group.scss
@@ -30,7 +30,8 @@
     // `font-size` in combination with `inline-block` on buttons.
     font-size: 0;
 
-    > .btn {
+    > .btn,
+    .form-group:last-of-type & > .btn {
         margin-top: 0;
     }
 }


### PR DESCRIPTION
By using more specific input-group button selector, fixes #143