### PR TITLE
Fixed a straggler main.ipb.io --> test.ipdb.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@
 name:                   BigchainDB
 description:            'The scalable blockchain database.'
 url:                    https://www.bigchaindb.com
+ipdb_api_url:           https://test.ipdb.io
 
 email:
     contact:            contact@bigchaindb.com

--- a/_src/_assets/javascripts/page-getstarted.js
+++ b/_src/_assets/javascripts/page-getstarted.js
@@ -4,6 +4,8 @@
 //=include bigchain/smoothscroll.js
 //=include bigchain/newsletter.js
 
+const ipdbUrl = 'https://test.ipdb.io'
+
 jQuery(function($) {
 
     //
@@ -123,7 +125,7 @@ window.addEventListener('DOMContentLoaded', function domload(event) {
             const outputContent = JSON.stringify(response, null, 2) // indented with 2 spaces
             output.textContent = outputContent
 
-            transactionLink.href = 'https://test.ipdb.io/api/v1/transactions/' + response.id
+            transactionLink.href = ipdbUrl + '/api/v1/transactions/' + response.id
 
             postButton.classList.add('disabled')
             postButton.style.opacity = 0

--- a/_src/getstarted.html
+++ b/_src/getstarted.html
@@ -60,7 +60,7 @@ redirect_from:
 
                 <div class="message message--success alert alert--success hide">
                     <p>{{ content.firsttransaction.message.response }}</p>
-                    <p><a class="transaction-link" href="https://test.ipdb.io/api/v1/transactions/">Check out your transaction on IPDB</a></p>
+                    <p><a class="transaction-link" href="{{ site.ipdb_api_url }}/api/v1/transactions/">Check out your transaction on IPDB</a></p>
                 </div>
                 <p class="message message--fail alert alert--warning hide">Shenanigans! Something's off. Would you mind trying again?</p>
             </div>
@@ -88,7 +88,7 @@ from bigchaindb_driver.crypto import generate_keypair
 
 
 bdb = BigchainDB(
-    'https://test.ipdb.io/api/v1/',
+    '{{ site.ipdb_api_url }}/api/v1/',
     headers={'app_id': 'Get one from developers.ipdb.io',
              'app_key': 'Same as app_id'})
 alice = generate_keypair()
@@ -112,7 +112,7 @@ const driver = require('bigchaindb-driver')
 
 const alice = new driver.Ed25519Keypair()
 const conn = new driver.Connection(
-    'https://test.ipdb.io/api/v1/',
+    '{{ site.ipdb_api_url }}/api/v1/',
     { app_id: 'Get one from developers.ipdb.io',
       app_key: 'Same as app_id' })
 const tx = driver.Transaction.makeCreateTransaction(


### PR DESCRIPTION
@brucepon reported this to me.

There was another instance of main.ipdb.io hanging around, breaking a link on the /getstarted page. I fixed it.

Maybe there should be one central place where that base URL is set?