### PR TITLE
Add Ruby CLI Wrapper

### DIFF
--- a/_src/_data/drivers.yml
+++ b/_src/_data/drivers.yml
@@ -15,12 +15,12 @@ official:
       icon: logo-cli
 
 community:
-    - title: Ruby (CLI-Wrapper)
+    - title: Ruby (CLI wrapper)
       repo: bigchaindb-ruby-client
       icon: logo-ruby
       link: https://github.com/nileshtrivedi/bigchaindb-ruby-client
 
-    - title: Ruby (WIP)
+    - title: Ruby
       repo: bigchaindb_ruby
       icon: logo-ruby
       link: https://github.com/LicenseRocks/bigchaindb_ruby


### PR DESCRIPTION
There might be better ways to name those. 
The one that I added is based on the tx-cli and works (whereas the licenserocks driver doesn't work at this point).


Suggestions on naming? Maybe even remove licenserocks driver as they're not actively working on it at the moment?

Edit: I also just noticed that the ruby-cli one is missing a license. I'll get in touch with the author.

Edit2: Actually they published on rubygems. There they licensed under MIT. We should probably refer to rubygems then. If you want me to I can change the link