### PR TITLE
Fixed example Python code

### DIFF
--- a/_src/getstarted.html
+++ b/_src/getstarted.html
@@ -90,8 +90,8 @@ from bigchaindb_driver.crypto import generate_keypair
 
 bdb = BigchainDB(
     '{{ site.ipdb_api_url }}',
-    headers={'app_id': 'Get one from developers.ipdb.io',
-             'app_key': 'Same as app_id'})
+    headers={'app_id': 'Get credentials from developers.ipdb.io',
+             'app_key': 'by signing up and going to your Applications screen'})
 alice = generate_keypair()
 tx = bdb.transactions.prepare(
     operation='CREATE',
@@ -114,8 +114,8 @@ const driver = require('bigchaindb-driver')
 const alice = new driver.Ed25519Keypair()
 const conn = new driver.Connection(
     '{{ site.ipdb_api_url }}/api/v1/',
-    { app_id: 'Get one from developers.ipdb.io',
-      app_key: 'Same as app_id' })
+    { app_id: 'Get credentials from developers.ipdb.io',
+      app_key: 'by signing up and going to your Applications screen' })
 const tx = driver.Transaction.makeCreateTransaction(
     { message: 'Blockchain all the things!' },
     null,


### PR DESCRIPTION
On the Get Started page, the example Python code was slightly wrong. There should be no `/api/v1/` in the URL passed to `BigchainDB()`. This PR fixes that error. I made a similar fix on the IPDB Developer Portal home page a while back. I just noticed the same error was present on the Get Started page.

@kremalicious You may also want to change

```python
     headers={'app_id': 'Get one from developers.ipdb.io',
              'app_key': 'Same as app_id'})
```

because the app_key is _not_ the same as the app_id, but one might think so from that code snippet.