### PR TITLE
set GA IP Anonymization

### DIFF
--- a/_src/_includes/scripts.html
+++ b/_src/_includes/scripts.html
@@ -47,6 +47,9 @@ if (!_dntEnabled()) {
             });
         {% endif %}
 
+        // IP Anonymization
+        ga('set', 'anonymizeIp', true);
+
         // Send initial pageview
         ga('send', 'pageview');
 


### PR DESCRIPTION
To comply with German privacy laws and to not give Google more information than necessary.

https://support.google.com/analytics/answer/2763052?hl=en