### PR TITLE
Fix local development

### DIFF
--- a/_src/_plugins/blog.rb
+++ b/_src/_plugins/blog.rb
@@ -8,18 +8,18 @@ module Jekyll
 
     # Runs during jekyll build
     class RssFeedCollector < Generator
-       safe true
-       priority :high
-       def generate(site)
+    safe true
+    priority :high
+    def generate(site)
 
-          rss_items = SimpleRSS.parse open('https://blog.bigchaindb.com/feed/')
+        rss_items = SimpleRSS.parse open('https://blog.bigchaindb.com/feed/')
 
-          # Create a new on-the-fly Jekyll collection called "articles"
-          jekyll_items = Jekyll::Collection.new(site, 'articles')
-          site.collections['articles'] = jekyll_items
+        # Create a new on-the-fly Jekyll collection called "articles"
+        jekyll_items = Jekyll::Collection.new(site, 'articles')
+        site.collections['articles'] = jekyll_items
 
-          # Add fake virtual documents to the collection
-          rss_items.items.each do |item|
+        # Add fake virtual documents to the collection
+        rss_items.items.each do |item|
             title = item.title
             link = item.link
 
@@ -33,9 +33,10 @@ module Jekyll
             doc.data['link'] = link
             doc.data['image'] = image
             jekyll_items.docs << doc
-          end
-
-       end
+        end
+        rescue
+            puts "Could not parse blog feed. Are you offline?"
+        end
     end
 
 end

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -125,7 +125,13 @@ export const jekyll = (done) => {
 
     const jekyll = cp.execFile('bundle', ['exec', jekyll_options], { stdio: 'inherit' })
 
-    jekyll.on('error', (error) => onError() ).on('close', done)
+    const jekyllLogger = (buffer) => {
+        buffer.toString()
+            .split(/\n/)
+            .forEach((message) => console.log(message))
+    }
+
+    jekyll.stdout.on('data', jekyllLogger).on('close', done)
 }
 
 


### PR DESCRIPTION
Adds 2 things to solve #232:

- add a rescue statement to the blog feed fetching plugin so whole thing doesn't blow up when feed can't be accessed
- show actual Jekyll output in console so real error messages get passed through now. Like so:

<img width="505" alt="screen shot 2018-05-22 at 14 13 43" src="https://user-images.githubusercontent.com/90316/40361668-669b71e8-5dca-11e8-997f-d72880fd4efd.png">

Closes #232