### PR TITLE
output language above all code blocks

### DIFF
--- a/_src/_assets/javascripts/page-guide.js
+++ b/_src/_assets/javascripts/page-guide.js
@@ -10,7 +10,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
     const codeBlocks = document.querySelectorAll('.highlight')
 
     codeBlocks.forEach(codeBlock => {
+        const language = codeBlock.getElementsByTagName('code')[0].dataset.lang
+
         codeBlock.insertAdjacentHTML('afterbegin', clipboardButton)
+        codeBlock.insertAdjacentHTML('afterbegin', `<h6 class="highlight__title">${language}</h6>`)
     })
 
     const buttons = document.querySelectorAll('.highlight .btn--clipboard')

--- a/_src/_assets/styles/bigchain/_code.scss
+++ b/_src/_assets/styles/bigchain/_code.scss
@@ -77,15 +77,24 @@ pre {
     .btn--clipboard,
     .success__text {
         position: absolute;
-        top: .1rem;
+        top: $spacer * 1.65;
         right: .1rem;
     }
 
     .success__text {
-        top: 2rem;
+        top: $spacer * 3.5;
         right: -1.5rem;
         font-size: $font-size-xs;
     }
+}
+
+.highlight__title {
+    margin-top: 0;
+    margin-bottom: $spacer / 4;
+    margin-left: $spacer / 1.5;
+    font-size: $font-size-sm;
+    color: $gray-light;
+    display: inline-block;
 }
 
 .btn--clipboard {


### PR DESCRIPTION
Like so, automatically grabs the language from the `data-lang` attribute on the code block via javascript:

<img width="732" alt="screen shot 2018-08-28 at 18 35 32" src="https://user-images.githubusercontent.com/90316/44737029-2cc8d680-aaf1-11e8-8797-3be72283656b.png">

Interim solution, or first step for solving #254