### PR TITLE
add a space before meetup title

### DIFF
--- a/_src/_assets/javascripts/bigchain/meetup.js
+++ b/_src/_assets/javascripts/bigchain/meetup.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', function() {
             })
             const elementTitle = document.getElementsByClassName('meetup-title')[0]
 
-            elementTitle.innerHTML = `<span class="hero__community__label">${date}</span><strong>${name}</strong>`
+            elementTitle.innerHTML = `<span class="hero__community__label">${date}</span><strong> ${name}</strong>`
             elementTitle.style.opacity = 1
             element.href = link
         } else {


### PR DESCRIPTION
It looks horrible otherwise, horrible!

<img width="435" alt="screen shot 2018-09-04 at 12 52 52" src="https://user-images.githubusercontent.com/90316/45027356-72c9f100-b041-11e8-8734-fcff16b460fc.png">
