### PR TITLE
Updated 'Get Started' page for new testnet

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 name:                   BigchainDB
 description:            'The blockchain database.'
 url:                    https://www.bigchaindb.com
-bigchaindb_api_url:     https://test1.testnet2.com
+bigchaindb_api_url:     https://test.bigchaindb.com
 
 # set to `true` to make hiring link appear in main menu
 hiring:                 true

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 name:                   BigchainDB
 description:            'The blockchain database.'
 url:                    https://www.bigchaindb.com
-bigchaindb_api_url:     https://test.bigchaindb.com
+bigchaindb_api_url:     https://test1.testnet2.com
 
 # set to `true` to make hiring link appear in main menu
 hiring:                 true

--- a/_src/_assets/javascripts/page-getstarted.js
+++ b/_src/_assets/javascripts/page-getstarted.js
@@ -3,8 +3,7 @@
 //=include bigchain/tab.js
 //=include bigchain/newsletter.js
 
-const bigchaindbUrl = 'https://test.bigchaindb.com'
-const proxyUrl = 'https://getstarted.bigchaindb.com'
+const bigchaindbUrl = 'https://test1.testnet2.com'
 const apiPath = '/api/v1/'
 
 jQuery(function ($) {
@@ -81,7 +80,7 @@ window.addEventListener('DOMContentLoaded', function domload(event) {
     window.removeEventListener('DOMContentLoaded', domload, false)
 
     const driver = window.BigchainDB
-    const API_PATH = proxyUrl + apiPath
+    const API_PATH = bigchaindbUrl + apiPath
 
     const postButton = document.getElementById('post')
     const postButtonText = postButton.innerText

--- a/_src/_assets/javascripts/page-getstarted.js
+++ b/_src/_assets/javascripts/page-getstarted.js
@@ -3,7 +3,7 @@
 //=include bigchain/tab.js
 //=include bigchain/newsletter.js
 
-const bigchaindbUrl = 'https://test1.testnet2.com'
+const bigchaindbUrl = 'https://test.bigchaindb.com'
 const apiPath = '/api/v1/'
 
 jQuery(function ($) {

--- a/_src/_data/getstarted.yml
+++ b/_src/_data/getstarted.yml
@@ -25,8 +25,8 @@ server:
         title: "The BigchainDB Test Network"
         version_title: "The BigchainDB Test Network is currently running on BigchainDB "
         description: "No installation needed. We handle running a BigchainDB network for you."
-        button: "Get the URLs"
-        link: "https://info.testnet2.com"
+        button: "Visit the Test Network"
+        link: "https://test.bigchaindb.com"
     bdb:
         pretitle: "Self-Hosted"
         title: "BigchainDB Server"

--- a/_src/_data/getstarted.yml
+++ b/_src/_data/getstarted.yml
@@ -23,16 +23,16 @@ server:
     network:
         pretitle: "Managed"
         title: "The BigchainDB Test Network"
-        version_title: "Test Network is currently running on BigchainDB "
-        description: "No installation needed. Sign up and connect instantly, we will handle running a BigchainDB network for you."
-        button: "Sign up"
-        link: "https://testnet.bigchaindb.com"
+        version_title: "The BigchainDB Test Network is currently running on BigchainDB "
+        description: "No installation needed. We handle running a BigchainDB network for you."
+        button: "Get the URLs"
+        link: "https://info.testnet2.com"
     bdb:
         pretitle: "Self-Hosted"
         title: "BigchainDB Server"
-        description: "If you want to run your own BigchainDB instance, you can either get set up on Linux or with Docker on any system."
-        button: "Install BigchainDB Server"
-        link: "https://docs.bigchaindb.com/projects/server/en/latest/quickstart.html"
+        description: "If you want to deploy and run your own BigchainDB node or network, you can."
+        button: "Deploy a BigchainDB node"
+        link: "http://docs.bigchaindb.com/projects/server/en/latest/simple-deployment-template/index.html"
 
 
 # ----------------------------

--- a/_src/_guide/_setup.md
+++ b/_src/_guide/_setup.md
@@ -26,17 +26,17 @@ Then, include that as a module and connect to any BigchainDB node.
 ```js
 const BigchainDB = require('bigchaindb-driver')
 
-const API_PATH = 'https://test1.testnet2.com/api/v1/'
+const API_PATH = 'https://test.bigchaindb.com/api/v1/'
 const conn = new BigchainDB.Connection(API_PATH)
 ```
 
 ```python
 from bigchaindb_driver import BigchainDB
 
-conn = BigchainDB('https://test1.testnet2.com')
+conn = BigchainDB('https://test.bigchaindb.com')
 ```
 
 ```java
 BigchainDbConfigBuilder
-	.baseUrl("https://test1.testnet2.com/").setup();
+	.baseUrl("https://test.bigchaindb.com/").setup();
 ```

--- a/_src/_guide/_setup.md
+++ b/_src/_guide/_setup.md
@@ -21,30 +21,22 @@ pip install -U bigchaindb-driver
 </dependency>
 ```
 
-Then, include that as a module and connect to any BigchainDB node. You can create your own `app_id` and `app_key` on [BigchainDB Testnet](https://testnet.bigchaindb.com).
+Then, include that as a module and connect to any BigchainDB node.
 
 ```js
 const BigchainDB = require('bigchaindb-driver')
 
-const API_PATH = 'https://test.bigchaindb.com/api/v1/'
-const conn = new BigchainDB.Connection(API_PATH, {
-    app_id: 'Get one from testnet.bigchaindb.com',
-    app_key: 'Get one from testnet.bigchaindb.com'
-})
+const API_PATH = 'https://test1.testnet2.com/api/v1/'
+const conn = new BigchainDB.Connection(API_PATH)
 ```
 
 ```python
 from bigchaindb_driver import BigchainDB
 
-conn = BigchainDB(
-    'https://test.bigchaindb.com',
-    headers={'app_id': 'Get one from testnet.bigchaindb.com',
-             'app_key': 'Get one from testnet.bigchaindb.com'})
+conn = BigchainDB('https://test1.testnet2.com')
 ```
 
 ```java
 BigchainDbConfigBuilder
-	.baseUrl("https://test.bigchaindb.com/")
-	.addToken("app_id", "Get one from testnet.bigchaindb.com")
-	.addToken("app_key","Get one from testnet.bigchaindb.com").setup();
+	.baseUrl("https://test1.testnet2.com/").setup();
 ```

--- a/_src/_guide/tutorial-car-telemetry-app.md
+++ b/_src/_guide/tutorial-car-telemetry-app.md
@@ -72,12 +72,7 @@ const Orm = require('bigchaindb-orm')
 
 class DID extends Orm {
     constructor(entity) {
-        super(
-            API_PATH, {
-                app_id: 'Get one from testnet.bigchaindb.com',
-                app_key: 'Get one from testnet.bigchaindb.com'
-            }
-        )
+        super(API_PATH)
         this.entity = entity
     }
 }

--- a/_src/developers/getstarted.html
+++ b/_src/developers/getstarted.html
@@ -86,10 +86,7 @@ redirect_from:
 from bigchaindb_driver import BigchainDB
 from bigchaindb_driver.crypto import generate_keypair
 
-bdb = BigchainDB(
-    '{{ site.bigchaindb_api_url }}',
-    headers={'app_id': 'Get credentials from testnet.bigchaindb.com',
-             'app_key': 'by signing up and going to your Applications screen'})
+bdb = BigchainDB('{{ site.bigchaindb_api_url }}')
 alice = generate_keypair()
 tx = bdb.transactions.prepare(
     operation='CREATE',
@@ -109,10 +106,7 @@ bdb.transactions.send(signed_tx)
 const driver = require('bigchaindb-driver')
 
 const alice = new driver.Ed25519Keypair()
-const conn = new driver.Connection(
-    '{{ site.bigchaindb_api_url }}/api/v1/',
-    { app_id: 'Get credentials from testnet.bigchaindb.com',
-      app_key: 'by signing up and going to your Applications screen' })
+const conn = new driver.Connection('{{ site.bigchaindb_api_url }}/api/v1/')
 const tx = driver.Transaction.makeCreateTransaction(
     { message: 'Blockchain all the things!' },
     null,


### PR DESCRIPTION
The new testnet:
- doesn't have a node at https://test.bigchaindb.com
- does have a node at https://test1.testnet2.com
- doesn't require `app_key` or `app_id` in the HTTP request headers, so there's no need to call to a proxy app to add those

Note: The button to "Get the URLs" links to https://info.testnet2.com but I haven't implemented that yet, so **please don't merge this pull request yet**.