### PR TITLE
Update "We're hiring" link but also turn it off in main menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ url:                    https://www.bigchaindb.com
 bigchaindb_api_url:     https://test.bigchaindb.com
 
 # set to `true` to make hiring link appear in main menu
-hiring:                 true
+hiring:                 false
 
 email:
     contact:            contact@bigchaindb.com

--- a/_src/_includes/menu-main.html
+++ b/_src/_includes/menu-main.html
@@ -10,7 +10,7 @@
                     </svg>
                 </a>
                 {% if site.hiring == true %}
-                    <a class="menu__hiring" href="https://github.com/bigchaindb/org/tree/master/jobs" rel="external">
+                    <a class="menu__hiring" href="https://github.com/bigchaindb/org/tree/master/archive/jobs" rel="external">
                         <svg class="icon icon--suitcase"><use xlink:href="/assets/img/sprite.svg#icon-suitcase"></use></svg>
                         We're hiring!
                     </a>


### PR DESCRIPTION
I realize that the entire bigchaindb.com site will probably get overhauled completely in the coming months, but I figured we should do this change ASAP.