### PR TITLE
Problem: "single" is spelled "singe"

### DIFF
--- a/_src/features.html
+++ b/_src/features.html
@@ -6,7 +6,7 @@ description: "Rather than trying to enhance blockchain technology, BigchainDB st
 
 features:
      - title: "Decentralization"
-       text: "No single point of control. No singe point of failure. Decentralized control via a federation of voting nodes makes for a P2P network."
+       text: "No single point of control. No single point of failure. Decentralized control via a federation of voting nodes makes for a P2P network."
        icon: "icon-nodes"
      - title: "Query"
        text: "Write and run any MongoDB query to search the contents of all stored transactions, assets, metadata and blocks. Powered by MongoDB itself."


### PR DESCRIPTION
This typo in the `/features/` page was noticed by someone reading the bigchaindb.com website and they emailed us about it. I thought I was the only person who did that. I guess not :smile: 