### PR TITLE
Update menus.yml: remove Services at top of page

### DIFF
--- a/_src/_data/menus.yml
+++ b/_src/_data/menus.yml
@@ -12,8 +12,6 @@ main:
         - title: Docs
           url: https://docs.bigchaindb.com/
           external: true
-    - title: Services
-      url: /services/
 
 secondary:
     - title: About


### PR DESCRIPTION
bigchaindb.com/services page will still exist. But it's just not prominently linked. Another PR has changed the content of the services page to basically just point to IPDB Foundation.