### PR TITLE
Update menus.yml: remove little-supported community links

### DIFF
--- a/_src/_data/menus.yml
+++ b/_src/_data/menus.yml
@@ -26,16 +26,8 @@ secondary:
       url: "/contact/"
 
 community:
-    - title: Gitter
-      url: https://gitter.im/bigchaindb/bigchaindb
     - title: GitHub
       url: https://github.com/bigchaindb
-    - title: Twitter
-      url: https://twitter.com/BigchainDB
-    - title: Facebook
-      url: https://www.facebook.com/BigchainDB/
-    - title: Meetup
-      url: https://www.meetup.com/BigchainDB-IPDB-Meetup
 
 legal:
     - title: Terms


### PR DESCRIPTION
Removed: Gitter, Twitter, Facebook, Meetup
Kept: GitHub