### PR TITLE
Update banner.html: move ocean logo

### DIFF
--- a/_src/_includes/banner.html
+++ b/_src/_includes/banner.html
@@ -3,11 +3,7 @@
     <a class="banner--oceanprotocol oceanprotocol" href="https://oceanprotocol.com/?utm_source=bigchaindb.com&utm_medium=banner&utm_campaign=ocean_banner">
         <div class="row row--wide">
             <h1 class="oceanprotocol__title">
-                BigchainDB GmbH (the company) works on Ocean Protocol 
-                <svg class="oceanprotocol__logo">
-                    <use xlink:href="/assets/img/sprite.svg#logo-oceanprotocol"></use>
-                </svg>
-                , whereas IPDB Foundation (ipdb.io) oversees BigchainDB software and networks.</h1>
+                BigchainDB GmbH (the company) works on Ocean Protocol. IPDB Foundation (ipdb.io) oversees BigchainDB software and networks.</h1>
         </div>
     </a>
 

--- a/_src/_includes/banner.html
+++ b/_src/_includes/banner.html
@@ -3,10 +3,11 @@
     <a class="banner--oceanprotocol oceanprotocol" href="https://oceanprotocol.com/?utm_source=bigchaindb.com&utm_medium=banner&utm_campaign=ocean_banner">
         <div class="row row--wide">
             <h1 class="oceanprotocol__title">
+                BigchainDB GmbH (the company) works on Ocean Protocol 
                 <svg class="oceanprotocol__logo">
                     <use xlink:href="/assets/img/sprite.svg#logo-oceanprotocol"></use>
                 </svg>
-                BigchainDB GmbH (the company) works on Ocean Protocol. IPDB Foundation (ipdb.io) oversees BigchainDB software and networks.</h1>
+                , whereas IPDB Foundation (ipdb.io) oversees BigchainDB software and networks.</h1>
         </div>
     </a>
 


### PR DESCRIPTION
Monica had a small piece of feedback. In the banner on the top, having the Ocean logo next to "BigchainDB GmbH" is confusing. Possible solutions: fully remove logo, or move it next to "Ocean Protocol" in the banner. This commit moves it.